### PR TITLE
Update commentreply.md with cleaner link to source code

### DIFF
--- a/templates/commentreply.md
+++ b/templates/commentreply.md
@@ -6,4 +6,4 @@ The following re-uploads of this video are available:
 
 ---
 
-[^look ^at ^my ^programming](https://amirror.link/source)
+[^(look at my programming)](https://amirror.link/source)


### PR DESCRIPTION
Hello Kyle,

I recently learned some more about reddit's `^`, which allows the comments posted by this bot to be slightly prettier **in the new version of reddit.**
Note, these issues do not seem to exist on the old design of reddit.

# Description

I ran across this comment posted by what appears to be your bot.
![image](https://user-images.githubusercontent.com/37621491/74679783-14ee8200-51bf-11ea-8a90-778e65f5a7ed.png)
at https://new.reddit.com/r/PublicFreakout/comments/f5946k/turn_down_for_what/fhx8ogv?utm_source=share&utm_medium=web2x
I noticed the iffy link, and figured I could try to help make this look more professional.

There are essentially two problems. As you know, the code used in the actual comment is the following: `[^look ^at ^my ^programming](https://amirror.link/source)`.

## Problem 1
The `^programming` is not reduced in size. Moreso, the `^` is still visible within the message. This can be resolved by placing a space inbetween `^programming` and the `]`, as the space is used by the `^` to be sure that a word has ended. The markdown for this fix is the following: 
`[^look ^at ^my ^programming ](https://amirror.link/source)`.
This would improve upon the current situation. However, there's more fixes possible.

## Problem 2
Between all words of the sentence that make up the link, there are small blue lines at the "normal" height. This causes the link to look a bit funky. This too can be resolved. We can use brackets after the `^` to move text up as a group, rather than per word:
`[^(look at my programming)](https://www.example.com)` will produce a clean link.

## After applying the Fix shown in Problem 2
The following image shows the current situation **in new reddit**, after applying a fix for problem 1, and after applying a fix for problem 2, followed by a copy of the markdown that was used:
![image](https://user-images.githubusercontent.com/37621491/74680363-a6122880-51c0-11ea-85bf-1f416e2b7067.png)
This can be experienced on new reddit at the following link: https://new.reddit.com/r/test/comments/f5dx2l/test/

# How to reproduce
You can browse to https://new.reddit.com/r/PublicFreakout/comments/f5946k/turn_down_for_what/fhx8ogv/ to experience the iffy link posted by your bot account yourself.

# What now?
As the only change proposed in my commit was related to formatting, there should be no bugs introduced. Though do understand that I did not explicitly test whether a message sent by the bot will be displayed correctly in the new design of reddit.

---

Thanks for putting this bot together, it has been useful.