### PR TITLE
chore: upgrade SnooBrowser

### DIFF
--- a/ApplicationData/ApplicationData.csproj
+++ b/ApplicationData/ApplicationData.csproj
@@ -25,7 +25,7 @@
       <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.6" />
       <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
       <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
-      <PackageReference Include="SnooBrowser" Version="3.1.1" />
+      <PackageReference Include="SnooBrowser" Version="3.1.2" />
       <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     </ItemGroup>
 

--- a/BackgroundProcessor/BackgroundProcessor.csproj
+++ b/BackgroundProcessor/BackgroundProcessor.csproj
@@ -18,8 +18,8 @@
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
-        <PackageReference Include="SnooBrowser" Version="3.1.1" />
-        <PackageReference Include="SnooBrowser.Extensions.DependencyInjection" Version="3.1.1" />
+        <PackageReference Include="SnooBrowser" Version="3.1.2" />
+        <PackageReference Include="SnooBrowser.Extensions.DependencyInjection" Version="3.1.2" />
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     </ItemGroup>
 

--- a/WebApi/WebApi.csproj
+++ b/WebApi/WebApi.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.2.0" />
     <PackageReference Include="Sentry.AspNetCore" Version="4.7.0" />
-    <PackageReference Include="SnooBrowser.Extensions.DependencyInjection" Version="3.1.1" />
+    <PackageReference Include="SnooBrowser.Extensions.DependencyInjection" Version="3.1.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
     <PackageReference Include="System.Runtime.Caching" Version="8.0.0" />


### PR DESCRIPTION
This ended up being necessary because the transitive resolution of FruityFoundation.Base resulted in invalid method calls coming from SnooBrowser.

SnooBrowser has been upgraded to use the latest FruityFoundation.Base version.
